### PR TITLE
Fix whitespace around table environment.

### DIFF
--- a/nddiss2e.cls
+++ b/nddiss2e.cls
@@ -674,13 +674,14 @@
   \vskip\belowcaptionskip\normalspacing }%
   \end{center}
 }%
-\renewenvironment{table}{%
+\renewenvironment{table}[1][tbp]{%
    \setlength{\abovecaptionskip}{\abovetableskip}
    \setlength{\belowcaptionskip}{\belowtableskip}
-   \singlespacing
    \renewcommand{\arraystretch}{\double@baselinestretch}
    \let\@makecaption\@maketablecaption
-   \@float{table}}%
+   \@float{table}[#1]%
+   \singlespacing%
+   }%
    {%
    \addtocontents{lot}{ {\vskip 0.4em} }%
    \end@float%

--- a/nddiss2e.dtx
+++ b/nddiss2e.dtx
@@ -2056,13 +2056,14 @@
 % the entry itself is single-spaced. Similar to that in
 % |\@makefigurecaption|, a |\vskip| is added to each entry in the |.lot| file.
 %    \begin{macrocode}
-\renewenvironment{table}{%
+\renewenvironment{table}[1][tbp]{%
    \setlength{\abovecaptionskip}{\abovetableskip}
    \setlength{\belowcaptionskip}{\belowtableskip}
-   \singlespacing
    \renewcommand{\arraystretch}{\double@baselinestretch}
    \let\@makecaption\@maketablecaption
-   \@float{table}}%
+   \@float{table}[#1]%
+   \singlespacing%
+   }%
    {%
    \addtocontents{lot}{ {\vskip 0.4em} }%
    \end@float%


### PR DESCRIPTION
Fixes spurious whitespace/newlines that occur in the main text where a table environment is used. In the following example, this is visible via the difference in the gap between "Foo" and "Bar" and the following sentence:
```latex
\section{Foo}

A sentence.

\section{Bar}

\begin{table}[tb]
  Some table%
\end{table}%
\begin{table}[tb]
  Some other table%
\end{table}%

Another sentence
```