### PR TITLE
XeLaTeX does not like \pdfadjustspacing and needs shell-escape.

### DIFF
--- a/nddiss2e.cls
+++ b/nddiss2e.cls
@@ -130,7 +130,7 @@
   \RequirePackage{color}
   \RequirePackage{graphicx}
   \AtBeginDocument{
-  \pdfadjustspacing=1
+  \ifpdf\pdfadjustspacing=1\fi
   }
 }{%
   \RequirePackage[dvips]{epsfig}

--- a/nddiss2e.dtx
+++ b/nddiss2e.dtx
@@ -13,7 +13,7 @@
 % \fi
 %
 %
-%  \CheckSum{1468}
+%  \CheckSum{1470}
 %  \CharacterTable
 %   {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
 %    Lower-case    \a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z
@@ -56,6 +56,7 @@
 %<*driver>
 \ProvidesFile{nddiss2e.dtx}
 \documentclass{ltxdoc}
+\usepackage{metalogo}
 \setcounter{secnumdepth}{2}
 \setcounter{tocdepth}{2}
 \DeclareRobustCommand{\nddiss}{%
@@ -145,6 +146,13 @@
 %   \endgraf\vskip\belowtableskip}%
 %   \hss}}}
 % \makeatother
+% \end{verbatim}
+%
+% Due to limitations in the \textsf{pdfx} package, when using
+% \XeLaTeX, shell commands have to be permitted and the document to be
+% compile as follows:
+% \begin{verbatim}
+% xelatex -shell-escape thesis
 % \end{verbatim}
 %
 % \subsection{History}
@@ -1074,7 +1082,7 @@
   \RequirePackage{color}
   \RequirePackage{graphicx}
   \AtBeginDocument{
-  \pdfadjustspacing=1
+  \ifpdf\pdfadjustspacing=1\fi
   }
 }{%
   \RequirePackage[dvips]{epsfig}


### PR DESCRIPTION
As per pdfx documentation, `xelatex` needs to be run with the option `-shell-escape`.

Fixes #4.