### PR TITLE
Update abbrvnat to 1.93 (natbib 8.31b)

### DIFF
--- a/nddiss2e.bst
+++ b/nddiss2e.bst
@@ -6,7 +6,7 @@
 %% File: `abbrvnat.bst'
 %% A modification of `abbrv.bst' for use with natbib package 
 %%
-%% Copyright 1993-2005 Patrick W Daly
+%% Copyright 1993-2007 Patrick W Daly
 %% Max-Planck-Institut f\"ur Sonnensystemforschung
 %% Max-Planck-Str. 2
 %% D-37191 Katlenburg-Lindau
@@ -19,7 +19,7 @@
 %% version 1 of the License, or any later version.
 %%
  % Version and source file information:
- % \ProvidesFile{natbst.mbs}[2005/01/07 1.8 (PWD)]
+ % \ProvidesFile{natbst.mbs}[2007/11/26 1.93 (PWD)]
  %
  % BibTeX `plainnat' family
  %   version 0.99b for BibTeX versions 0.99a or later,
@@ -646,9 +646,9 @@ FUNCTION {format.article.crossref}
         { "In \emph{" journal * "}" * }
       if$
     }
-    { "In " key * }
+    { "In " }
   if$
-  " \citep{" * crossref * "}" *
+  " \citet{" * crossref * "}" *
 }
 
 FUNCTION {format.book.crossref}
@@ -672,12 +672,12 @@ FUNCTION {format.book.crossref}
             { "\emph{" * series * "}" * }
           if$
         }
-        { key * }
+        'skip$
       if$
     }
     'skip$
   if$
-  ", \citet{" * crossref * "}" *
+  " \citet{" * crossref * "}" *
 }
 
 FUNCTION {format.incoll.inproc.crossref}
@@ -693,7 +693,7 @@ FUNCTION {format.incoll.inproc.crossref}
             { "In \emph{" booktitle * "}" * }
           if$
         }
-        { "In " key * }
+        { "In " }
       if$
     }
     { "In " }
@@ -1007,10 +1007,10 @@ FUNCTION {unpublished}
   author format.key output
   new.block
   format.title "title" output.check
-  format.url output
   new.block
   note "note" output.check
   format.date output
+  format.url output
   fin.entry
 }
 
@@ -1334,6 +1334,10 @@ FUNCTION {presort}
       if$
     }
   if$
+  "    "
+  *
+  year field.or.null sortify
+  *
   "    "
   *
   cite$

--- a/nddiss2enoarticletitles.bst
+++ b/nddiss2enoarticletitles.bst
@@ -6,7 +6,7 @@
 %% File: `abbrvnat.bst'
 %% A modification of `abbrv.bst' for use with natbib package 
 %%
-%% Copyright 1993-2005 Patrick W Daly
+%% Copyright 1993-2007 Patrick W Daly
 %% Max-Planck-Institut f\"ur Sonnensystemforschung
 %% Max-Planck-Str. 2
 %% D-37191 Katlenburg-Lindau
@@ -19,7 +19,7 @@
 %% version 1 of the License, or any later version.
 %%
  % Version and source file information:
- % \ProvidesFile{natbst.mbs}[2005/01/07 1.8 (PWD)]
+ % \ProvidesFile{natbst.mbs}[2007/11/26 1.93 (PWD)]
  %
  % BibTeX `plainnat' family
  %   version 0.99b for BibTeX versions 0.99a or later,
@@ -646,9 +646,9 @@ FUNCTION {format.article.crossref}
         { "In \emph{" journal * "}" * }
       if$
     }
-    { "In " key * }
+    { "In " }
   if$
-  " \citep{" * crossref * "}" *
+  " \citet{" * crossref * "}" *
 }
 
 FUNCTION {format.book.crossref}
@@ -672,12 +672,12 @@ FUNCTION {format.book.crossref}
             { "\emph{" * series * "}" * }
           if$
         }
-        { key * }
+        'skip$
       if$
     }
     'skip$
   if$
-  ", \citet{" * crossref * "}" *
+  " \citet{" * crossref * "}" *
 }
 
 FUNCTION {format.incoll.inproc.crossref}
@@ -693,7 +693,7 @@ FUNCTION {format.incoll.inproc.crossref}
             { "In \emph{" booktitle * "}" * }
           if$
         }
-        { "In " key * }
+        { "In " }
       if$
     }
     { "In " }
@@ -1007,10 +1007,10 @@ FUNCTION {unpublished}
   author format.key output
   new.block
   format.title "title" output.check
-  format.url output
   new.block
   note "note" output.check
   format.date output
+  format.url output
   fin.entry
 }
 
@@ -1334,6 +1334,10 @@ FUNCTION {presort}
       if$
     }
   if$
+  "    "
+  *
+  year field.or.null sortify
+  *
   "    "
   *
   cite$


### PR DESCRIPTION
nddiss2e.bst was created based on abbrvnat 1.8 (with essentially no customizations). This PR updates the underlying abbrvnat code to 1.93 (natbib 8.31b, which is what TeX Live uses).

These differences to abbrvnat.bst can be viewed here: https://tug.org/svn/texlive/trunk/Master/texmf-dist/bibtex/bst/natbib/abbrvnat.bst?view=diff&r1=12056&r2=71&diff_format=h