### PR TITLE
Justify figure captions

### DIFF
--- a/nddiss2e.cls
+++ b/nddiss2e.cls
@@ -662,7 +662,7 @@
   \vskip\abovecaptionskip
   \begin{center}
   \parbox{\capwidth}{
-    \centering\singlespacing
+    \singlespacing
     {#1}. {#2}%\par
   \vskip\belowcaptionskip\normalspacing }%
   \end{center}


### PR DESCRIPTION
To be more in line with the `threeparttable` table notes, this simple change removes the `\centering` from figure captions, making them justified instead.

Fixes #16.