### PR TITLE
Remove spaces from \work, \advisor, and other fields in template.tex

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -56,23 +56,23 @@
 
 \frontmatter             % All the items before Chapter 1 go in ``frontmatter''
 
-\title{ Title of Work }  % Title
+\title{Title of Work}    % Title
 
-\author{ Jane Doe }      % Author's name
-\work{ Dissertation }    % ``Dissertation'' or ``Thesis''
-\degaward{ Doctor of Philosophy }  % Degree you're aiming for.
+\author{Jane Doe}        % Author's name
+\work{Dissertation}      % ``Dissertation'' or ``Thesis''
+\degaward{Doctor of Philosophy}    % Degree you're aiming for.
                                    % Should be one of the following options:
                                    % ``Doctor of Philosophy'' (do NOT include ``in Subject'')
                                    % ``Master of Science \\ in \\ Subject''
-\advisor{ John Public }  % Advisor's name
- % \secondadvisor{ }     % Second advisor, if used option ``twoadvisors''
-\program{ }              % Name of the graduate program
+\advisor{John Public}    % Advisor's name
+ % \secondadvisor{}      % Second advisor, if used option ``twoadvisors''
+\program{}               % Name of the graduate program
 
 \maketitle               % The title page is created now
 
  % You must use either the \makecopyright option or the \makepublicdomain option.
- % \copyrightholder{ }   % If you're not the copyright holder
- % \copyrightyear{ }     % If the copyright is not for the current year
+ % \copyrightholder{}    % If you're not the copyright holder
+ % \copyrightyear{}      % If the copyright is not for the current year
  % \makecopyright        % If not making your work public domain
                          % uncomment out \makecopyright
  % \makepublicdomain     % Uncomment this to make your work public domain


### PR DESCRIPTION
The spaces in these fields were causing unwanted spaces in the title page.

Alternatively, these macros could be redefined to eat up leading and trailing spaces; I can submit a new PR for that if desired.
